### PR TITLE
Updated slack version, removed gdebi, fixed a version conflict bug

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-slack_version: 3.1.1
+slack_version: 4.4.2

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: apt-get update
   apt: update_cache=true cache_valid_time=3600
-  sudo: yes
+  become: yes
 
 - name: Check if slack is installed
   command: dpkg-query -W slack-desktop
@@ -16,7 +16,7 @@
   when: check_slack.rc == 1
 
 - name: Install Ubuntu slack package
-  sudo: true
+  become: yes
   apt:
     deb: "/tmp/slack-desktop-{{ slack_version }}-amd64.deb"
   when: check_slack.rc == 1

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -3,10 +3,6 @@
   apt: update_cache=true cache_valid_time=3600
   sudo: yes
 
-- name: install gdebi
-  apt: name=gdebi
-  sudo: yes
-
 - name: Check if slack is installed
   command: dpkg-query -W slack-desktop
   register: check_slack
@@ -21,5 +17,6 @@
 
 - name: Install Ubuntu slack package
   sudo: true
-  command: gdebi --non-interactive /tmp/slack-desktop.deb
+  apt:
+    deb: /tmp/slack-desktop.deb
   when: check_slack.rc == 1

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -10,13 +10,13 @@
   changed_when: false
 
 - name: Download Ubuntu slack package
-  command: "wget -O /tmp/slack-desktop.deb https://downloads.slack-edge.com/linux_releases/slack-desktop-{{ slack_version }}-amd64.deb"
-  args:
-    creates: "/tmp/slack-desktop.deb"
+  get_url:
+    url: "https://downloads.slack-edge.com/linux_releases/slack-desktop-{{ slack_version }}-amd64.deb"
+    dest: "/tmp/slack-desktop-{{ slack_version }}-amd64.deb"
   when: check_slack.rc == 1
 
 - name: Install Ubuntu slack package
   sudo: true
   apt:
-    deb: /tmp/slack-desktop.deb
+    deb: "/tmp/slack-desktop-{{ slack_version }}-amd64.deb"
   when: check_slack.rc == 1

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,7 +1,7 @@
 ---
 - name: install slack with yum or apt
   action: "{{backcompat_pkg_mgr}} name=https://downloads.slack-edge.com/linux_releases/slack-2.2.1-0.1.fc21.x86_64.rpm"
-  sudo: yes
+  become: yes
   when: backcompat_pkg_mgr == "yum" or backcompat_pkg_mgr == "apt"
 
 # Handle dnf case for Fedora
@@ -15,5 +15,5 @@
 # Use command since dnf was only added as a module in ansible 1.9.0
 - name: install slack with dnf
   command: dnf install -y https://downloads.slack-edge.com/linux_releases/slack-2.2.1-0.1.fc21.x86_64.rpm
-  sudo: yes
+  become: yes
   when: backcompat_pkg_mgr == "dnf" and package_exists_result|failed

--- a/tasks/compat.yml
+++ b/tasks/compat.yml
@@ -1,6 +1,6 @@
 ---
 - name: install python-apt on ansible < 1.6.0 and ubuntu et al
-  sudo: yes
+  become: yes
   raw: >
     if > /dev/null command -v apt-get; then
        python -c "import apt" ||
@@ -12,7 +12,7 @@
   changed_when: False
 
 - name: install python-pycurl on ansible < 1.6.0 and ubuntu et al
-  sudo: yes
+  become: yes
   raw: >
     if > /dev/null command -v apt-get; then
        python -c "import pycurl" ||
@@ -24,7 +24,7 @@
   changed_when: False
 
 - name: install python2-yum on ansible <=1.9.2/fedora 24
-  sudo: yes
+  become: yes
   raw: >
     if > /dev/null command -v yum && ! > /dev/null command -v dnf; then
        python -c "import yum" ||
@@ -34,7 +34,7 @@
   changed_when: False
 
 - name: install python2-dnf on ansible 2.1/fedora 24
-  sudo: yes
+  become: yes
   raw: >
     if > /dev/null command -v dnf; then
        python -c "import dnf" ||
@@ -83,7 +83,7 @@
 # Install wget due to https://github.com/ansible/ansible/issues/12161
 - name: install wget with non-dnf
   action: "{{backcompat_pkg_mgr}} name=wget"
-  sudo: yes
+  become: yes
   when: >
     (backcompat_pkg_mgr == "yum" or backcompat_pkg_mgr == "apt")
        and wget_result|failed
@@ -94,5 +94,5 @@
   command: dnf install -y wget
   args:
     creates: /usr/bin/wget
-  sudo: yes
+  become: yes
   when: backcompat_pkg_mgr == "dnf" and wget_result|failed


### PR DESCRIPTION
- Updated default slack version from 3.1.1 to 4.4.2
- Removed gdebi dependency, which is unnecessary and caused the role to succeed without actually installing
- Changed downloaded file name to contain version, so that the task won't be skipped if there is another version previously downloaded